### PR TITLE
Use the map frame as default

### DIFF
--- a/bitbots_ball_filter/config/params.yaml
+++ b/bitbots_ball_filter/config/params.yaml
@@ -4,8 +4,8 @@ ball_position_publish_topic: 'ball_position_relative_filtered'
 ball_movement_publish_topic: 'ball_relative_movement'
 ball_publish_topic: 'ball_relative_filtered'
 
-filter_frame: 'odom'
-# filter_frame: 'map'
+#filter_frame: 'odom'
+filter_frame: 'map'
 
 # Filtering rate in Hz
 filter_rate: 10


### PR DESCRIPTION
## Proposed changes
* Changes param

Some tests in webots resulted in much better results when filtering in the `map` frame.

## Necessary checks
- [x] Run `catkin build`
- [x] Test on your machine
- [x] Put the PR on our Project board

