### PR TITLE
Reset ball filter

### DIFF
--- a/bitbots_ball_filter/CMakeLists.txt
+++ b/bitbots_ball_filter/CMakeLists.txt
@@ -21,6 +21,8 @@ add_service_files(
 
 catkin_python_setup()
 
+generate_messages()
+
 #add dynamic reconfigure api
 #find_package(catkin REQUIRED dynamic_reconfigure)
 generate_dynamic_reconfigure_options(

--- a/bitbots_ball_filter/CMakeLists.txt
+++ b/bitbots_ball_filter/CMakeLists.txt
@@ -9,7 +9,15 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   rospy
   dynamic_reconfigure
+  message_generation
+  message_runtime
 )
+
+## Generate services in the 'srv' folder
+add_service_files(
+   FILES
+   ResetBallFilter.srv
+ )
 
 catkin_python_setup()
 

--- a/bitbots_ball_filter/CMakeLists.txt
+++ b/bitbots_ball_filter/CMakeLists.txt
@@ -6,22 +6,21 @@ project(bitbots_ball_filter)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  geometry_msgs
   rospy
+  std_msgs
+  std_srvs
+  geometry_msgs
+  tf2_geometry_msgs
+  humanoid_league_msgs
   dynamic_reconfigure
-  message_generation
-  message_runtime
 )
 
 ## Generate services in the 'srv' folder
 add_service_files(
    FILES
-   ResetBallFilter.srv
  )
 
 catkin_python_setup()
-
-generate_messages()
 
 #add dynamic reconfigure api
 #find_package(catkin REQUIRED dynamic_reconfigure)

--- a/bitbots_ball_filter/CMakeLists.txt
+++ b/bitbots_ball_filter/CMakeLists.txt
@@ -15,11 +15,6 @@ find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
 )
 
-## Generate services in the 'srv' folder
-add_service_files(
-   FILES
- )
-
 catkin_python_setup()
 
 #add dynamic reconfigure api

--- a/bitbots_ball_filter/cfg/BallFilter.cfg
+++ b/bitbots_ball_filter/cfg/BallFilter.cfg
@@ -23,6 +23,7 @@ group_ROS.add("ball_subscribe_topic", str_t, 0, "", None)
 group_ROS.add("ball_position_publish_topic", str_t, 0, "", None)
 group_ROS.add("ball_movement_publish_topic", str_t, 0, "", None)
 group_ROS.add("ball_publish_topic", str_t, 0, "", None)
+group_ROS.add("ball_filter_reset_service_name", str_t, 0, "Name of service for resetting the ball filter", None)
 group_ROS.add("use_frame", str_t, 0, "Choose a frame to use", "odom", edit_method=frames_chooser_enum)
 
 

--- a/bitbots_ball_filter/cfg/BallFilter.cfg
+++ b/bitbots_ball_filter/cfg/BallFilter.cfg
@@ -24,6 +24,7 @@ group_ROS.add("ball_position_publish_topic", str_t, 0, "", None)
 group_ROS.add("ball_movement_publish_topic", str_t, 0, "", None)
 group_ROS.add("ball_publish_topic", str_t, 0, "", None)
 group_ROS.add("filter_frame", str_t, 0, "Choose a frame to use", "odom", edit_method=frames_chooser_enum)
+group_ROS.add("ball_filter_reset_service_name", str_t, 0, "Name of service for resetting the ball filter", None)
 
 
 group_filter.add("filter_rate", int_t, 0, "Filtering rate in Hz", min=0, max=255)

--- a/bitbots_ball_filter/config/params.yaml
+++ b/bitbots_ball_filter/config/params.yaml
@@ -4,6 +4,8 @@ ball_position_publish_topic: 'ball_position_relative_filtered'
 ball_movement_publish_topic: 'ball_relative_movement'
 ball_publish_topic: 'ball_relative_filtered'
 
+ball_filter_reset_service_name: 'ball_filter_reset'
+
 #filter_frame: 'odom'
 filter_frame: 'map'
 

--- a/bitbots_ball_filter/package.xml
+++ b/bitbots_ball_filter/package.xml
@@ -15,10 +15,12 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
   <depend>dynamic_reconfigure</depend>
 
 

--- a/bitbots_ball_filter/package.xml
+++ b/bitbots_ball_filter/package.xml
@@ -13,14 +13,12 @@
 
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_export_depend>geometry_msgs</build_export_depend>
-  <build_export_depend>rospy</build_export_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <depend>rospy</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>humanoid_league_msgs</depend>
   <depend>dynamic_reconfigure</depend>
 
 

--- a/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
+++ b/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
@@ -120,6 +120,11 @@ class BallFilter:
             except (tf2.ConnectivityException, tf2.LookupException, tf2.ExtrapolationException) as e:
                 rospy.logwarn(e)
 
+    def reset_filter_cb(self, req):
+        rospy.loginfo("Resetting bitbots ball filter...", logger_name="ball_filter")
+        self.filter_initialized = False
+        return True
+
     def filter_step(self, event):
         """"
         When ball has been assigned a value and filter has been initialized:
@@ -156,19 +161,6 @@ class BallFilter:
             return np.array([self.ball.point.x, self.ball.point.y])
         except AttributeError as e:
             rospy.logwarn(f"Did you reconfigure? Something went wrong... {e}", logger_name="ball_filter")
-
-    def reset_filter_cb(self, req):
-        self.reset_filter(req.x, req.y)
-
-    def reset_filter(self, x, y):
-        """
-        Reinitializes kalmanfilter at given position
-
-        :param x: start x position of the ball
-        :param y: start y position of the ball
-        """
-        self.filter_initialized = False
-        self.init_filter(x, y)
 
     def init_filter(self, x, y):
         """

--- a/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
+++ b/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
@@ -122,6 +122,11 @@ class BallFilter:
             except (tf2.ConnectivityException, tf2.LookupException, tf2.ExtrapolationException) as e:
                 rospy.logwarn(e)
 
+    def reset_filter_cb(self, req):
+        rospy.loginfo("Resetting bitbots ball filter...", logger_name="ball_filter")
+        self.filter_initialized = False
+        return True
+
     def filter_step(self, event):
         """"
         When ball has been assigned a value and filter has been initialized:
@@ -168,19 +173,6 @@ class BallFilter:
             return np.array([self.ball.point.x, self.ball.point.y])
         except AttributeError as e:
             rospy.logwarn(f"Did you reconfigure? Something went wrong... {e}", logger_name="ball_filter")
-
-    def reset_filter_cb(self, req):
-        self.reset_filter(req.x, req.y)
-
-    def reset_filter(self, x, y):
-        """
-        Reinitializes kalmanfilter at given position
-
-        :param x: start x position of the ball
-        :param y: start y position of the ball
-        """
-        self.filter_initialized = False
-        self.init_filter(x, y)
 
     def init_filter(self, x, y):
         """

--- a/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
+++ b/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
@@ -12,9 +12,9 @@ from humanoid_league_msgs.msg import (PoseWithCertainty,
                                       PoseWithCertaintyArray,
                                       PoseWithCertaintyStamped)
 from std_msgs.msg import Header
+from std_srvs.srv import Trigger
 from tf2_geometry_msgs import PointStamped
 
-from bitbots_ball_filter.srv import ResetBallFilter
 from bitbots_ball_filter.cfg import BallFilterConfig
 
 
@@ -96,7 +96,7 @@ class BallFilter:
         
         self.reset_service = rospy.Service(
             config['ball_filter_reset_service_name'],
-            ResetBallFilter,
+            Trigger,
             self.reset_filter_cb
         )
 

--- a/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
+++ b/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
@@ -47,7 +47,7 @@ class BallFilter:
         self.filter_initialized = False
         self.ball = None  # type: PointStamped
         self.ball_header = None  # type: Header
-        self.last_ball_msg = None  # type: PoseWithCertainty
+        self.last_ball_msg = PoseWithCertainty()  # type: PoseWithCertainty
 
         self.filter_rate = config['filter_rate']
         self.measurement_certainty = config['measurement_certainty']
@@ -158,6 +158,13 @@ class BallFilter:
                 state = self.kf.get_update()
                 self.publish_data(*state)
                 self.last_state = state
+            else:
+                # Publish old state with huge covariance
+                state, cov_mat = self.kf.get_update()
+                huge_cov_mat = np.ones_like(cov_mat) * 10
+                self.publish_data(state, huge_cov_mat)
+                self.last_state = state, huge_cov_mat
+
 
     def distance_to_ball(self, state):
         state_x = state[0]

--- a/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
+++ b/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
@@ -161,7 +161,7 @@ class BallFilter:
             else:
                 # Publish old state with huge covariance
                 state, cov_mat = self.kf.get_update()
-                huge_cov_mat = np.ones_like(cov_mat) * 10
+                huge_cov_mat = np.eye(cov_mat.shape[0]) * 10
                 self.publish_data(state, huge_cov_mat)
                 self.last_state = state, huge_cov_mat
 

--- a/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
+++ b/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
@@ -125,7 +125,7 @@ class BallFilter:
     def reset_filter_cb(self, req):
         rospy.loginfo("Resetting bitbots ball filter...", logger_name="ball_filter")
         self.filter_initialized = False
-        return True
+        return True, ""
 
     def filter_step(self, event):
         """"

--- a/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
+++ b/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
@@ -13,9 +13,9 @@ from humanoid_league_msgs.msg import (PoseWithCertainty,
                                       PoseWithCertaintyArray,
                                       PoseWithCertaintyStamped)
 from std_msgs.msg import Header
+from std_srvs.srv import Trigger
 from tf2_geometry_msgs import PointStamped
 
-from bitbots_ball_filter.srv import ResetBallFilter
 from bitbots_ball_filter.cfg import BallFilterConfig
 
 
@@ -98,7 +98,7 @@ class BallFilter:
         
         self.reset_service = rospy.Service(
             config['ball_filter_reset_service_name'],
-            ResetBallFilter,
+            Trigger,
             self.reset_filter_cb
         )
 

--- a/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
+++ b/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
@@ -15,6 +15,7 @@ from humanoid_league_msgs.msg import (PoseWithCertainty,
 from std_msgs.msg import Header
 from tf2_geometry_msgs import PointStamped
 
+from bitbots_ball_filter.srv import ResetBallFilter
 from bitbots_ball_filter.cfg import BallFilterConfig
 
 
@@ -94,6 +95,13 @@ class BallFilter:
             self.ball_callback,
             queue_size=1
         )
+        
+        self.reset_service = rospy.Service(
+            config['ball_filter_reset_service_name'],
+            ResetBallFilter,
+            self.reset_filter_cb
+        )
+
         self.config = config
         self.filter_timer = rospy.Timer(rospy.Duration(self.filter_time_step), self.filter_step)
         return config
@@ -128,7 +136,6 @@ class BallFilter:
                 self.filter_initialized = False
             if not self.filter_initialized:
                 self.init_filter(*self.get_ball_measurement())
-                self.filter_initialized = True
             self.kf.predict()
             self.kf.update(self.get_ball_measurement())
             state = self.kf.get_update()
@@ -162,13 +169,25 @@ class BallFilter:
         except AttributeError as e:
             rospy.logwarn(f"Did you reconfigure? Something went wrong... {e}", logger_name="ball_filter")
 
-    def init_filter(self, x, y):
+    def reset_filter_cb(self, req):
+        self.reset_filter(req.x, req.y)
+
+    def reset_filter(self, x, y):
         """
-        initializes kalmanfilter at given position
+        Reinitializes kalmanfilter at given position
 
         :param x: start x position of the ball
         :param y: start y position of the ball
-        :return:
+        """
+        self.filter_initialized = False
+        self.init_filter(x, y)
+
+    def init_filter(self, x, y):
+        """
+        Initializes kalmanfilter at given position
+
+        :param x: start x position of the ball
+        :param y: start y position of the ball
         """
         # initial value of position(x,y) of the ball and velocity
         self.kf.x = np.array([x, y, 0, 0])
@@ -190,6 +209,8 @@ class BallFilter:
 
         # assigning process noise
         self.kf.Q = Q_discrete_white_noise(dim=2, dt=self.filter_time_step, var=self.process_noise_variance, block_size=2, order_by_dim=False)
+
+        self.filter_initialized = True
 
     def publish_data(self, state: np.array, cov_mat: np.array) -> None:
         """

--- a/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
+++ b/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
@@ -123,7 +123,7 @@ class BallFilter:
     def reset_filter_cb(self, req):
         rospy.loginfo("Resetting bitbots ball filter...", logger_name="ball_filter")
         self.filter_initialized = False
-        return True
+        return True, ""
 
     def filter_step(self, event):
         """"

--- a/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
+++ b/bitbots_ball_filter/src/bitbots_ball_filter/ball_filter.py
@@ -46,7 +46,7 @@ class BallFilter:
         self.filter_initialized = False
         self.ball = None  # type:PointStamped
         self.ball_header = None  # type: Header
-        self.last_ball_msg = None  # type: PoseWithCertainty
+        self.last_ball_msg = PoseWithCertainty()  # type: PoseWithCertainty
 
         self.filter_rate = config['filter_rate']
         self.measurement_certainty = config['measurement_certainty']
@@ -154,6 +154,13 @@ class BallFilter:
                 state = self.kf.get_update()
                 self.publish_data(*state)
                 self.last_state = state
+            else:
+                # Publish old state with huge covariance
+                state, cov_mat = self.kf.get_update()
+                huge_cov_mat = np.ones_like(cov_mat) * 10
+                self.publish_data(state, huge_cov_mat)
+                self.last_state = state, huge_cov_mat
+
 
     def get_ball_measurement(self):
         """extracts filter measurement from ball message"""

--- a/bitbots_ball_filter/srv/ResetBallFilter.srv
+++ b/bitbots_ball_filter/srv/ResetBallFilter.srv
@@ -1,3 +1,0 @@
-
----
-bool success

--- a/bitbots_ball_filter/srv/ResetBallFilter.srv
+++ b/bitbots_ball_filter/srv/ResetBallFilter.srv
@@ -1,0 +1,5 @@
+float32 x
+float32 y
+
+---
+bool success

--- a/bitbots_ball_filter/srv/ResetBallFilter.srv
+++ b/bitbots_ball_filter/srv/ResetBallFilter.srv
@@ -1,5 +1,3 @@
-float32 x
-float32 y
 
 ---
 bool success


### PR DESCRIPTION
## Proposed changes
Adds a service to enable resetting the ball filter (as necessary for the behavior)

## Related issues
bit-bots/bitbots_behavior/pull/233

## Necessary checks
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

